### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/mjtener/bfacfc80-1308-46ba-a0fb-5ed6873f3062/c75d2fb9-424d-409f-b483-052500dccb65/_apis/work/boardbadge/3f0b07bb-0844-4994-9eab-b76cb1a1e8d7)](https://dev.azure.com/mjtener/bfacfc80-1308-46ba-a0fb-5ed6873f3062/_boards/board/t/c75d2fb9-424d-409f-b483-052500dccb65/Microsoft.RequirementCategory)
 # maximum_spam


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/mjtener/bfacfc80-1308-46ba-a0fb-5ed6873f3062/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.